### PR TITLE
Expose the Left Animated Property to the given menu Component

### DIFF
--- a/index.js
+++ b/index.js
@@ -236,13 +236,38 @@ class SideMenu extends Component {
 
     return (
       <Animated.View
-        style={[styles.frontView, { width, height, }, this.props.animationStyle(this.state.left), ]}
+        style={[styles.frontView, { width, height, },
+          this.props.animationStyle(this.state.left, this.interpolateToPercentage(this.state.left)),]}
         ref={(sideMenu) => this.sideMenu = sideMenu}
         {...this.responder.panHandlers}>
         {this.props.children}
         {overlay}
       </Animated.View>
     );
+  }
+
+  /**
+   * Returns the property interpolated
+   * on a scale from 0 to 100
+   *
+   * @param prop {Animated.Value}
+   * @returns {Animated.Value}
+   */
+  interpolateToPercentage(prop) {
+    if (this.menuPositionMultiplier() > 0) {
+      return prop.interpolate({
+        inputRange : [0, this.props.openMenuOffset - this.props.hiddenMenuOffset],
+        outputRange: [0, 100]
+      });
+    } else {
+      // When the menu is on the right, the whole interpolation reverses
+      // in order to maintain the 0 to 100 scale intact. Again, the client
+      // should only care about the open ratio, not about directions.
+      return prop.interpolate({
+        inputRange : [this.props.hiddenMenuOffset - this.props.openMenuOffset, 0],
+        outputRange: [100, 0]
+      });
+    }
   }
 
   /**
@@ -274,7 +299,14 @@ class SideMenu extends Component {
      * If menu is ready to be rendered
      */
     if (this.state.shouldRenderMenu) {
-      menu = <View style={styles.menu}>{this.props.menu}</View>;
+      let menuProps = {
+        openPercentage: this.interpolateToPercentage(this.state.left)
+      };
+
+      // Attach the openPercentage Prop to the given menu
+      menu = <View style={styles.menu}>
+        {React.cloneElement(this.props.menu, menuProps)}
+      </View>;
     }
 
     return (


### PR DESCRIPTION
This PR exposes the Left AnimatedValue to the Menu Component, and additionally interpolates it on a scale from 1 to 100 (percentage). Here are the reasons for both additions:
1. Say the Menu Content's behavior depends on the Menu open ratio, like so:
   ![e97d31d78e03005f54a8224b39758044](https://cloud.githubusercontent.com/assets/2099521/11408458/465dd34a-9387-11e5-85c1-235f85027250.gif)
   or 
   ![4b59ed942f3dd1a2b0c83e178cfdfa76](https://cloud.githubusercontent.com/assets/2099521/11408536/d57bd770-9387-11e5-9631-dad523d2dcc2.gif)

(^ each individual item is animated separately - notice the slight delay in each one of them)

Without, having direct access to the Left AnimatedValue, such behavior is not really possible, without having to apply some proper hacking :)

_(\* The only way to get access to the Left AnimatedValue that I found, is to grab the leftValue from the animationStyle method, attach a listener to it, save the returned exact value, to the current Component's state, and pass that value down to the MenuContent Component, but besides being sooo hacky, it is also noticeable less performant)_
1. Exposing the LeftValue interpolated to percentage instead of the concrete pixel value, is in my opinion, a much flexible approach, since now, the consumers don't need to care about device widths, offsets or any other pixel type of measurements.

The interpolated LeftValue is called "openPercentage" and is automatically passed down to the MenuContent Component as a property and to animationStyle() as the 2nd param, so it doesn't break the current API.
